### PR TITLE
adds ajax call to home page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem 'awesome_print'
 gem 'pry'
 gem 'figaro'
 gem 'faraday'
-
+gem "font-awesome-rails"
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,8 @@ GEM
     ffi (1.9.18)
     figaro (1.1.1)
       thor (~> 0.14)
+    font-awesome-rails (4.7.0.2)
+      railties (>= 3.2, < 5.2)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     hashdiff (0.3.6)
@@ -234,6 +236,7 @@ DEPENDENCIES
   fabrication
   faraday
   figaro
+  font-awesome-rails
   jbuilder (~> 2.5)
   jquery-rails
   launchy

--- a/app/assets/javascripts/home_page/dayEvents.js
+++ b/app/assets/javascripts/home_page/dayEvents.js
@@ -1,0 +1,55 @@
+
+function todayEventsBrain(){
+  clearCurrentData()
+  currentEventDate.date = new Date
+  changeEventDateHeader()
+  getTodayEvents()
+}
+
+function allEventsBrain(){
+  clearCurrentData()
+  $("#current-event-date-header-capsule").hide()
+  currentEventDate.date = new Date
+  getNewEvents("current")
+}
+
+function clearCurrentData(){
+  $('#current-events-list').empty()
+}
+
+function getTodayEvents(){
+  today = new Date
+  $.ajax({
+        url: `http://localhost:3000/api/v1/events/today`,
+        type: 'get',
+        success:function(data){populateNewEvents(data, "current")
+        }
+      })
+    }
+//
+
+var currentEventDate = {
+  date: new Date
+}
+
+function currentEventDateChange(dateModifier){
+  currentEventDate.date.setDate(currentEventDate.date.getDate() + dateModifier)
+  changeEventDateHeader()
+  getModifiedDateEvents()
+}
+
+function getModifiedDateEvents(){
+  $.ajax({
+    url:  'http://localhost:3000/api/v1/events/modified_date_events',
+    type: 'get',
+    data: {date:currentEventDate.date.getTime()/1000},
+    success: function(data){
+      clearCurrentData()
+      populateNewEvents(data, "current")}
+  })
+}
+
+function changeEventDateHeader(){
+$("#current-event-date-header-capsule").show()
+$("#current-event-date-header-capsule")[0].innerHTML=`${formatDate(currentEventDate.date)}`
+}

--- a/app/assets/javascripts/home_page/eventLists.js
+++ b/app/assets/javascripts/home_page/eventLists.js
@@ -1,0 +1,36 @@
+$(document).ready(function(){
+  if(window.location.pathname =="/"){
+    startGettingEvents()
+  }
+})
+
+function startGettingEvents(){
+  var events = ["new", "current"]
+  for(i=0; i<events.length; i++){
+    getNewEvents(events[i])
+  }
+}
+
+function getNewEvents(events){
+$.ajax({
+    url: `http://localhost:3000/api/v1/events/${events}_events`,
+    type: 'get',
+    success: function(data){
+      populateNewEvents(data, events)
+    }
+  })
+}
+
+function populateNewEvents(data, passedEvent){
+  for(i=0; i<data.length; i++){
+
+  $(`#${passedEvent}-events-list`).append(
+    `<li class="list-group-item">
+       <a href="/events/${data[i].id}">${data[i].name}</a><br>
+       ${formatDate(new Date(data[i].start_time))} - ${formatDate(new Date(data[i].end_time))}
+       <p>Location: ${data[i].place}</p>
+       <p>${data[i].description.substr(0,300)}...</p>
+     </li>`
+    )
+  }
+}

--- a/app/assets/javascripts/tools/formatDate.js
+++ b/app/assets/javascripts/tools/formatDate.js
@@ -1,0 +1,14 @@
+function formatDate(date){
+  var monthNames = [
+    "Jan", "Feb", "Mar",
+    "Apr", "May", "June", "July",
+    "Aug", "Sept", "Oct",
+    "Nov", "Dec"
+  ];
+
+  var day = date.getDate();
+  var monthIndex = date.getMonth();
+  var year = date.getFullYear();
+
+  return monthNames[monthIndex] + ' ' + day + ', ' + year;
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -12,6 +12,7 @@
  *
  *= require_tree .
  *= require_self
+ *= require font-awesome
  */
 
  h1 {
@@ -26,4 +27,70 @@
 .container-fluid {
   margin-top: 10px;
   height: 60px;
+}
+
+.new-events {
+  margin-top: 100px;
+}
+
+#new-event-heading{
+  text-align: center;
+}
+
+#new-event-header{
+  margin-bottom: 20px;
+  border-style: ridge;
+}
+
+#new-event-list{
+  max-height: 600px;
+  overflow-y:scroll;
+}
+
+#new-event-column{
+  border-style: solid;
+  border-color: #19334d;
+  padding-top: 20px;
+  padding-bottom: 20px;
+}
+
+#new-event-container{
+  margin-bottom: 30px;
+}
+
+#current-event-heading{
+  text-align: center;
+}
+
+#current-event-header{
+  margin-bottom: 20px;
+  border-style: ridge;
+}
+#current-event-column{
+  border-style: solid;
+  border-color: #19334d;
+  padding-top: 20px;
+  padding-bottom: 20px;
+}
+
+#current-event-container{
+  margin-top: 30px;
+}
+
+#current-event-list{
+  max-height: 600px;
+  overflow-y:scroll;
+}
+
+.list-group-item{
+  border-style: solid;
+  border-color: #19334d;
+}
+
+#date-navigation{
+  text-align: center;
+}
+
+#current-event-date-header-capsule{
+  text-align: center;
 }

--- a/app/controllers/api/v1/events/current_events_controller.rb
+++ b/app/controllers/api/v1/events/current_events_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::Events::CurrentEventsController < ApplicationController
+
+  def index
+    render json: Event.current_events
+  end
+end

--- a/app/controllers/api/v1/events/day_events_controller.rb
+++ b/app/controllers/api/v1/events/day_events_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::Events::DayEventsController < ApplicationController
+
+  def index
+    render json: Event.day_events
+  end
+
+end

--- a/app/controllers/api/v1/events/modified_date_events_controller.rb
+++ b/app/controllers/api/v1/events/modified_date_events_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::Events::ModifiedDateEventsController < ApplicationController
+
+  def index
+    render json: Event.modified_date_events(params[:date])
+  end
+
+end

--- a/app/controllers/api/v1/events/new_events_controller.rb
+++ b/app/controllers/api/v1/events/new_events_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::Events::NewEventsController < ApplicationController
 
-  def new_events
-    render json: Event.where(created_at: (Time.now - 24.hours)..Time.now)
+  def index
+    render json: Event.new_events
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,6 @@
 class HomeController < ApplicationController
   def show
-
+    
   end
 
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -18,4 +18,25 @@ class Event < ActiveRecord::Base
   validates :fb_id,
 
             uniqueness: true
+
+
+
+
+
+
+  def self.new_events
+    where(created_at: (Time.now - 24.hours)..Time.now).reverse[0..24]
+  end
+
+  def self.current_events
+    where("end_time > ?", Time.now).order(:end_time).limit(100)
+  end
+
+  def self.day_events
+    Event.where('start_time < ? AND end_time >?',Date.parse(Time.now.end_of_day.to_s), Date.parse(Time.now.beginning_of_day.to_s)).order(:end_time)
+  end
+
+  def self.modified_date_events(date)
+    Event.where('start_time < ? AND end_time >?',Time.at(date.to_f).end_of_day, Time.at(date.to_f).beginning_of_day).order(:end_time)
+  end
 end

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -1,1 +1,45 @@
-<h1> hello </h1>
+<div class="new-events">
+  <div class="container" id="new-event-container">
+    <div class="row">
+      <div class="col">
+      </div>
+        <div class="col-9 rounded" id="new-event-column">
+          <div id="new-event-header">
+            <h2 id="new-event-heading"><u>New Events</u></h2>
+          </div>
+          <div id="new-event-list">
+            <ul class="list-group" id="new-events-list">
+            </ul>
+          </div>
+      </div>
+      <div class="col">
+      </div>
+    </div>
+  </div>
+  <div class="container" id="current-event-container">
+    <div class="row">
+      <div class="col">
+      </div>
+        <div class="col-9 rounded" id="current-event-column">
+          <div id="current-event-header">
+            <h2 id="current-event-heading"><u>Events</u></h2>
+            <div id="date-navigation">
+              <i onclick="currentEventDateChange(-1)" class="fa fa-chevron-left" aria-hidden="true"></i>
+              <strong><span onclick="allEventsBrain()">  All  </span></strong>
+              <strong><span onclick="todayEventsBrain()">Today  </span></strong>
+              <i onclick="currentEventDateChange(1)" class="fa fa-chevron-right" aria-hidden="true"></i>
+            </div>
+            <div id="current-event-date-header-capsule" style="display:none">
+              <p id ="current-event-date-header"></p>
+            </div>
+          </div>
+          <div id="current-event-list">
+            <ul class="list-group" id="current-events-list">
+            </ul>
+          </div>
+      </div>
+      <div class="col">
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,14 +2,15 @@
 <html>
   <head>
     <title>BrewMaster</title>
-      <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"></script>
+    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
       <!-- Latest compiled and minified CSS -->
-        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-      <!-- Optional theme -->
-        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
-      <!-- Latest compiled and minified JavaScript -->
-        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
-          <%= csrf_meta_tags %>
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css" integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M" crossorigin="anonymous">
+        <script src="//cdnjs.cloudflare.com/ajax/libs/list.js/1.5.0/list.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/paginationjs/2.0.8/pagination.min.js"></script>
+
+
+    <%= csrf_meta_tags %>
 
     <%= stylesheet_link_tag    'application', media: 'all' %>
     <%= javascript_include_tag 'application' %>
@@ -19,5 +20,8 @@
     <%= render 'navbar/navbar' %>
 
     <%= yield %>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js" integrity="sha384-b/U6ypiBEHpOf/4+1nzFpr53nxSS+GLCkfwBdFNTxtclqqenISfwAzpKaMNFNmj4" crossorigin="anonymous"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/js/bootstrap.min.js" integrity="sha384-h0AbiXch4ZDo7tp9hKZ4TsHbi047NrKGLO3SEJAg45jXxnGIfYzk4Si90RDIqNm1" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/app/views/navbar/_navbar.html.erb
+++ b/app/views/navbar/_navbar.html.erb
@@ -1,54 +1,29 @@
-<nav class="navbar navbar-default navbar-fixed-top">
-  <div class="container-fluid">
-
-    <div class="navbar-header">
-   <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
-     <span class="sr-only">Toggle navigation</span>
-     <span class="icon-bar"></span>
-     <span class="icon-bar"></span>
-     <span class="icon-bar"></span>
-   </button>
-   <a class="navbar-brand" href="#">Brand</a>
- </div>
-
- <!-- Collect the nav links, forms, and other content for toggling -->
- <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-   <ul class="nav navbar-nav">
-     <li class="active"><a href="#">Link <span class="sr-only">(current)</span></a></li>
-     <li><a href="#">Link</a></li>
-     <li class="dropdown">
-       <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Dropdown <span class="caret"></span></a>
-       <ul class="dropdown-menu">
-         <li><a href="#">Action</a></li>
-         <li><a href="#">Another action</a></li>
-         <li><a href="#">Something else here</a></li>
-         <li role="separator" class="divider"></li>
-         <li><a href="#">Separated link</a></li>
-         <li role="separator" class="divider"></li>
-         <li><a href="#">One more separated link</a></li>
-       </ul>
-     </li>
-   </ul>
-   <form class="navbar-form navbar-left">
-     <div class="form-group">
-       <input type="text" class="form-control" placeholder="Search">
-     </div>
-     <button type="submit" class="btn btn-default">Submit</button>
-   </form>
-   <ul class="nav navbar-nav navbar-right">
-     <li><a href="#">Link</a></li>
-     <li class="dropdown">
-       <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Dropdown <span class="caret"></span></a>
-       <ul class="dropdown-menu">
-         <li><a href="#">Action</a></li>
-         <li><a href="#">Another action</a></li>
-         <li><a href="#">Something else here</a></li>
-         <li role="separator" class="divider"></li>
-         <li><a href="#">Separated link</a></li>
-       </ul>
-     </li>
-   </ul>
- </div><!-- /.navbar-collapse -->
-
+<nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top ">
+  <a class="navbar-brand" href="/">Brew O'Clock</a>
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarNavDropdown">
+    <ul class="navbar-nav">
+      <li class="nav-item active">
+        <a class="nav-link" href="#">Home <span class="sr-only">(current)</span></a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="#">Features</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="#">Pricing</a>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="http://example.com" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Dropdown link
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+          <a class="dropdown-item" href="#">Action</a>
+          <a class="dropdown-item" href="#">Another action</a>
+          <a class="dropdown-item" href="#">Something else here</a>
+        </div>
+      </li>
+    </ul>
   </div>
 </nav>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,10 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       namespace :events do
-        get "/new_events", to: "new_events#new_events"
+        get "/new_events",           to: "new_events#index"
+        get "/current_events",       to: "current_events#index"
+        get "/today",                to: "day_events#index"
+        get "/modified_date_events", to: "modified_date_events#index"
       end
     end
   end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -19,6 +19,6 @@
 
 # Learn more: http://github.com/javan/whenever
 
-every 10.minutes do
-  rake "db:seed:seed_event"
-end
+# every 10.minutes do
+#   rake "db:seed:seed_event"
+# end


### PR DESCRIPTION
pulling new events to populate a list of new events on the home page

adds most recent 10 events to home page

newest event list created

on home page. Scrollable list of the most recent 25 events created. Needs more styling to complete

added fixed top to navbar

add current_events api endpoint

returns json of events that end after the current time and are ordered by their start time

adds current events list to home page

utilizes previous js algorithm to populate both new and current events

added date and location to new/current events on home page

adds navigation between dates list for events
includes forwards, backwards, all, and today selections for showing events

adds date header to current events on home page

date header changes with switching dates and is removed when viewing all events

change height of new events