### PR TITLE
Fix new events api endpoint

### DIFF
--- a/app/assets/javascripts/eventIndex/dayEvents.js
+++ b/app/assets/javascripts/eventIndex/dayEvents.js
@@ -1,4 +1,3 @@
-
 function todayEventsBrain(){
   clearCurrentData()
   currentEventDate.date = new Date

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -27,7 +27,7 @@ class Event < ApplicationRecord
 
 
   def self.new_events
-    where(created_at: (Time.now - 24.hours)..Time.now).reverse
+    where(created_at: (Time.now - 24.hours)..Time.now).limit(100).reverse
   end
 
   def self.current_events

--- a/lib/tasks/create_breweries.rake
+++ b/lib/tasks/create_breweries.rake
@@ -332,7 +332,7 @@ task :create_breweries => :environment do
         response = Faraday.get("https://graph.facebook.com/v2.10/#{id}?fields=about%2Ccover%2Cdescription%2Cemails%2Cfounded%2Cgeneral_info%2Chours%2Clocation%2Cphone%2Cname%2Cwebsite&access_token=#{@token}")
         parsed = JSON.parse(response.body, symbolize_names: true)
         sanitized = sanitize_brewery_data(parsed)
-        Brewery.new({
+        brewery = Brewery.new({
                       name:        sanitized[:name],
                       fb_id:       sanitized[:id],
                       phone:       sanitized[:phone],
@@ -345,7 +345,7 @@ task :create_breweries => :environment do
                       photo:       sanitized[:cover][:source],
                       url:         sanitized[:website]
                       })
-        if Brewery.save
+        if brewery.save
           puts "Created #{parsed[:name]} brewery"
         else
           puts "Could not create #{brewery}"


### PR DESCRIPTION
Limits new events endpoint to 50 to keep page from bloating after reseeding db with events. 